### PR TITLE
Undo changes that prevented output of all detectors for WFSC Global Alignment; Add SM move boresight shift model

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -454,22 +454,17 @@ class AptInput:
                             # This block should catch full-frame observations
                             # in either imaging (including TS imaging) or
                             # wfss mode
-                            if template != 'WfscGlobalAlignment':
-                                matched_aps = np.array([ap for ap in matched_apertures if 'GRISM' not in ap])
-                                matched_apertures = []
-                                detectors = []
-                                for ap in matched_aps:
-                                    detectors.append(ap[3:5])
-                                    split = ap.split('_')
-                                    if len(split) == 3:
-                                        ap_string = '{}_{}'.format(split[1], split[2])
-                                    elif len(split) == 2:
-                                        ap_string = split[1]
-                                    matched_apertures.append(ap_string)
-                            else:
-                                det_str, ap_str = input_dictionary['aperture'][index].split('_')
-                                matched_apertures = [ap_str]
-                                detectors = [det_str[3:5]]
+                            matched_aps = np.array([ap for ap in matched_apertures if 'GRISM' not in ap])
+                            matched_apertures = []
+                            detectors = []
+                            for ap in matched_aps:
+                                detectors.append(ap[3:5])
+                                split = ap.split('_')
+                                if len(split) == 3:
+                                    ap_string = '{}_{}'.format(split[1], split[2])
+                                elif len(split) == 2:
+                                    ap_string = split[1]
+                                matched_apertures.append(ap_string)
 
                         elif mode == 'ts_grism':
                             # This block should get Grism Time Series


### PR DESCRIPTION
**Part 1:** 
Suggested revision to https://github.com/spacetelescope/mirage/pull/492, following our discussions on Slack. 

Note, the way I set up my branch I also have merged in here the changes to segment PSF normalization from my PR https://github.com/spacetelescope/mirage/pull/546, so that's kind of redundant. It's the last commit 
cb4d247 that's most relevant for the fix. 

With this, I'm now getting all the NRCA# detector outputs again, as expected. 

**Part 2:** 
Now also includes a change that implements for segment PSFs a model for the effective boresight shifts induced by SM moves in tilt and translation. 

This is unrelated to the above, and arguably should be its own PR into MIRAGE, but I want to keep all my edits in one branch for now since I need them all at once...